### PR TITLE
アカウント状態による閲覧可否のバグの修正

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -1,12 +1,12 @@
 class WorksController < ApplicationController
-  before_action :authenticate_user!, except: :show
+  before_action :authenticate_user!
   before_action :find_contest, only: [:new, :create, :show, :edit, :update]
   before_action :find_work, only: [:show, :edit, :update, :finished]
 
   require './app/lib/file_validation'
 
   def show
-    if @contest.general == true && current_user.id != @contest.user.id
+    if @contest.general == false && current_user.id != @contest.user.id
       redirect_to contest_path(@contest.id)
     end
   end


### PR DESCRIPTION
# What
ユーザーが非ログイン、ログイン、ログインであれば投稿者本人かそうでないかによるページ閲覧の可否にあった誤りを修正

# Why
ページ閲覧権限の無いユーザにページを表示させないようにするため